### PR TITLE
Implement #23 - 게시판 컨트롤러 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 개발 환경
 
-- Intellij IDEA Ultimate 2023.1.5 - 
+- Intellij IDEA Ultimate 2023.1.5 - 2023.2
 - Java 17
 - Gradle 7.6.1
 - Spring Boot 2.7.13
@@ -71,15 +71,50 @@ class ArticleControllerTest {
 ```java
 @WebMvcTest(MainController.class)
 ```
-- MySQL에서 FK 제약조건이 걸려 있는 table을 drop 할 때는 `set FOREIGN_KEY_CHECKS = 0;`으로 제약 조건에 관계없이 table을 drop 할 수 있도록 설정하고, table drop 후 다시 `set FOREIGN_KEY_CHECKS = 1;`로 원상복구 해준다.
+- MySQL에서 FK 제약조건이 걸려 있는 table은 일반적인 방법으로 drop 할 수 없기 때문에 `set FOREIGN_KEY_CHECKS = 0;`으로 제약 조건에 관계없이 table을 drop 할 수 있도록 설정하고, table drop 후 다시 `set FOREIGN_KEY_CHECKS = 1;`로 원상복구 해준다.
 ```mysql
 set FOREIGN_KEY_CHECKS = 0;
 drop table [table_name];
 set FOREIGN_KEY_CHECKS = 1;
 ```
-- underscore(_)는 JPA method에서 property 탐색을 위한 traversal points(순회 지점)을 수동으로 설정하는 예약어(Property Expressions)이기 때문에 일반적인 경우에 사용해서는 안 된다. 아래와 같이 댓글 목록을 가져오는데 게시글의 id를 조회 조건으로 이용하거나, Pserson 객체의 목록을 조회하는데 Adderss 객체의 ZipCode property를 조회 조건으로 사용하는 등 property가 계층적(트리 구조) 연관관계를 가질 때 사용할 수 있다. 공식문서에서는 스네이크 표기법이 아닌 자바에서 사용하는 카멜표기법을 사용할 것을 추천하고 있다.
+- underscore(_)는 JPA Property Expressions에서 property 탐색을 위한 traversal points(순회 지점)을 수동으로 설정하는 예약어로 일반적인 경우에 사용해서는 안 된다. 아래와 같이 댓글 목록을 가져오는데 게시글의 id를 조회 조건으로 이용하거나, Pserson 객체의 목록을 조회하는데 Adderss 객체의 ZipCode property를 조회 조건으로 사용하는 등 property가 계층적(트리 구조) 연관관계를 가질 때 사용할 수 있다.
+- 공식 문서에서는 Property Expressions에 스네이크 표기법이 아닌 자바에서 사용하는 카멜표기법을 사용할 것을 추천하고 있다.
 - reference : https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-property-expressions
 ```java
 List<Person> findByAddress_ZipCode(ZipCode zipCode);
 List<ArticleComment> findByArticle_Id(Long articleId);
+```
+- `Page` interface의 `map` 메서드를 이용하여 DB에서 가져온 Entity Object를 간편하게 Dto로 변환할 수 있다.
+```java
+return articleRepository.findAll(pageable).map(ArticleDto::from);
+```
+- JPA method name에 `Containing`을 붙이면 부분 검색이 가능하다. 하지만 like `'%[keyword]%'`와 같이 % wild card가 앞뒤로 붙는 형태이므로 인덱스를 사용하지 못하여 성능 관련 이슈가 발생할 수 있다.
+```java
+Page<Article> findByContentContaining(String content, Pageable pageable);
+```
+- 보통 연관 관계에 있는 엔티티를 저장하기 위해 `findById()` 메서드를 사용하여 Entity를 불러오는데, 이는 불필요한 select문이 실행되는 결과를 낳는다. 이를 개선하기 위해 `getReferenceById()` 메서드를 사용하면 엔티티 생성에 프록시 객체를 넣어 주기 때문에 블필요한 select문이 실행되지 않는다.
+- 주의사항:  `findById()` 메서드는 Optional로 반환되기 때문에 예외 처리에 유리하지만, `getReferenceById()` 는 프록시 객체를 가져오기 때문에 예외 발생 위험이 있다.
+- `getOne()` 메서드는 Spring Boot 2.7에서 deprecated 되었고, 현재는 `getReferenceById()` 메서드 사용을 권장하고 있다. 
+- reference : https://docs.spring.io/spring-data/jpa/docs/current/api/deprecated-list.html
+```java
+Article article = articleRepository.getReferenceById(dto.id());
+```
+- `@MockBean` 애너테이션은 필드 주임만 가능하고 생성자 주입은 불가능하다. `@AutoWired` 애너테이션이 METHOD, PARAMETER 에서 사용할 수 있도록 구현이 되어 있는 반면, `@MockBean` 애너테이션은 TYPE, FIELD에서 사용할 수 있도록 구현이 되어 있다.
+```java
+// AutoWired 애너테이션
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Autowired {
+
+// MockBean 애너테이션
+@Target({ ElementType.TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Repeatable(MockBeans.class)
+public @interface MockBean {
+```
+- Mockito의 `any()` 메서드는 일종의 argument matcher로서 filed의 일부만 matrcher 할 수 없다. match 대상 field에 `eq()`를 사용하여 모든 method field가 argument matcher로 이루어져 있어야 에러가 나지 않는다.
+```java
+given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
 ```

--- a/src/main/java/com/matrix/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/matrix/projectboard/controller/ArticleController.java
@@ -1,10 +1,19 @@
 package com.matrix.projectboard.controller;
 
+import com.matrix.projectboard.domain.type.SearchType;
+import com.matrix.projectboard.dto.response.ArticleResponse;
+import com.matrix.projectboard.dto.response.ArticleWithCommentsResponse;
+import com.matrix.projectboard.service.ArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -13,23 +22,33 @@ import java.util.List;
  * date           : 2023-06-09
  * description    :
  */
-
+@RequiredArgsConstructor
 @RequestMapping("/articles")
 @Controller
 public class ArticleController {
 
+    private final ArticleService articleService;
+
     @GetMapping
-    public String articles(ModelMap map) {
-        map.addAttribute("articles", List.of());
+    public String articles(
+            @RequestParam(required = false) SearchType searchType,
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+    ) {
+        map.addAttribute("articles",
+                articleService.searchArticles(searchType, searchValue, pageable)
+                        .map(ArticleResponse::from)
+        );
 
         return "articles/index";
     }
 
     @GetMapping("/{articleId}")
-
     public String article(@PathVariable Long articleId, ModelMap map) {
-        map.addAttribute("article", "article"); // ToDo: 실제 데이터가 들어갈 수 있도록 구현 필요.
-        map.addAttribute("articleComments", List.of());
+        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
+        map.addAttribute("article", article);
+        map.addAttribute("articleComments", article.articleCommentsResponse());
 
         return "articles/detail";
     }

--- a/src/main/java/com/matrix/projectboard/dto/ArticleWithCommentsDto.java
+++ b/src/main/java/com/matrix/projectboard/dto/ArticleWithCommentsDto.java
@@ -34,8 +34,20 @@ public record ArticleWithCommentsDto(
             LocalDateTime createdAt,
             String createdBy,
             LocalDateTime modifiedAt,
-            String modifiedBy) {
-        return new ArticleWithCommentsDto(id, userAccountDto, articleCommentDtos, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
+            String modifiedBy
+    ) {
+        return new ArticleWithCommentsDto(
+                id,
+                userAccountDto,
+                articleCommentDtos,
+                title,
+                content,
+                hashtag,
+                createdAt,
+                createdBy,
+                modifiedAt,
+                modifiedBy
+        );
     }
 
     public static ArticleWithCommentsDto from(Article entity) {

--- a/src/main/java/com/matrix/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/matrix/projectboard/dto/response/ArticleCommentResponse.java
@@ -1,0 +1,44 @@
+package com.matrix.projectboard.dto.response;
+
+import com.matrix.projectboard.dto.ArticleCommentDto;
+
+import java.time.LocalDateTime;
+
+/**
+ * author         : Jason Lee
+ * date           : 2023-08-14
+ * description    :
+ */
+public record ArticleCommentResponse(
+        Long id,
+        String content,
+        LocalDateTime createdAt,
+        String email,
+        String nickname
+) {
+
+    public static ArticleCommentResponse of(
+            Long id,
+            String content,
+            LocalDateTime createdAt,
+            String email,
+            String nickname) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    }
+
+    public static ArticleCommentResponse from(ArticleCommentDto dto) {
+        String nickname = dto.userAccountDto().nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = dto.userAccountDto().userId();
+        }
+
+        return new ArticleCommentResponse(
+                dto.id(),
+                dto.content(),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname
+        );
+    }
+
+}

--- a/src/main/java/com/matrix/projectboard/dto/response/ArticleResponse.java
+++ b/src/main/java/com/matrix/projectboard/dto/response/ArticleResponse.java
@@ -1,0 +1,50 @@
+package com.matrix.projectboard.dto.response;
+
+import com.matrix.projectboard.dto.ArticleDto;
+
+import java.time.LocalDateTime;
+
+/**
+ * author         : Jason Lee
+ * date           : 2023-08-14
+ * description    :
+ */
+public record ArticleResponse(
+        Long id,
+        String title,
+        String content,
+        String hashtag,
+        LocalDateTime createdAt,
+        String email,
+        String nickname
+) {
+
+    public static ArticleResponse of(
+            Long id,
+            String title,
+            String content,
+            String hashtag,
+            LocalDateTime createdAt,
+            String email,
+            String nickname) {
+        return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);
+    }
+
+    public static ArticleResponse from(ArticleDto dto) {
+        String nickname = dto.userAccountDto().nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = dto.userAccountDto().userId();
+        }
+
+        return new ArticleResponse(
+                dto.id(),
+                dto.title(),
+                dto.content(),
+                dto.hashtag(),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname
+        );
+    }
+
+}

--- a/src/main/java/com/matrix/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/matrix/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -1,0 +1,67 @@
+package com.matrix.projectboard.dto.response;
+
+import com.matrix.projectboard.dto.ArticleWithCommentsDto;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * author         : Jason Lee
+ * date           : 2023-08-14
+ * description    :
+ */
+public record ArticleWithCommentsResponse(
+        Long id,
+        String title,
+        String content,
+        String hashtag,
+        LocalDateTime createdAt,
+        String email,
+        String nickname,
+        Set<ArticleCommentResponse> articleCommentsResponse
+) {
+
+    public static ArticleWithCommentsResponse of(
+            Long id,
+            String title,
+            String content,
+            String hashtag,
+            LocalDateTime createdAt,
+            String email,
+            String nickname,
+            Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentsResponse(
+                id,
+                title,
+                content,
+                hashtag,
+                createdAt,
+                email,
+                nickname,
+                articleCommentResponses
+        );
+    }
+
+    public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
+        String nickname = dto.userAccountDto().nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = dto.userAccountDto().userId();
+        }
+
+        return new ArticleWithCommentsResponse(
+                dto.id(),
+                dto.title(),
+                dto.content(),
+                dto.hashtag(),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname,
+                dto.articleCommentDtos().stream()
+                        .map(ArticleCommentResponse::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
+        );
+    }
+
+}

--- a/src/test/java/com/matrix/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/matrix/projectboard/controller/ArticleControllerTest.java
@@ -1,15 +1,26 @@
 package com.matrix.projectboard.controller;
 
 import com.matrix.projectboard.config.SecurityConfig;
+import com.matrix.projectboard.dto.ArticleWithCommentsDto;
+import com.matrix.projectboard.dto.UserAccountDto;
+import com.matrix.projectboard.service.ArticleService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -26,6 +37,9 @@ class ArticleControllerTest {
 
     private final MockMvc mvc;
 
+    @MockBean
+    private ArticleService articleService;
+
     public ArticleControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
@@ -34,6 +48,9 @@ class ArticleControllerTest {
     @Test
     public void givenNothing_whenRequestingArticlesView_thenReturnsArticlesView() throws Exception {
         // Given
+        // any() 메서드는 일종의 argument matcher인데 field 중 일부만 matcher를 할 수 없다.
+        // 이때 eq()를 사용하면 모든 method field가 argument matcher로 이루어져 있어서 에러가 나지 않는다.
+        given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
 
         // When & Then
         mvc.perform(get("/articles"))
@@ -41,25 +58,29 @@ class ArticleControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/index")) // 여기에 index라는 뷰 파일이 있어야 한다.
                 .andExpect(model().attributeExists("articles"));
+        then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
     }
 
     @DisplayName("[view][GET] 게시글 상세 페이지 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
         // Given
+        Long articleId = 1L;
+        given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentsDto());
 
         // When & Then
-        mvc.perform(get("/articles/1"))
+        mvc.perform(get("/articles/" + articleId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/detail"))
                 .andExpect(model().attributeExists("article"))
                 .andExpect(model().attributeExists("articleComments")); // 게시글 상세페이지에서는 댓글도 보여야 한다.
         // 이 때는 게시글 데이터가 model attribute 에 넘겨져야 한다.
+        then(articleService).should().getArticle(articleId);
     }
 
     @Disabled("구현 중")
-    // 게시판 페이지에서 검색 bar를 밑에 넣을 예정이라 이 테스트가 필요 없을 수 있다.
+    // ToDo: 게시판 페이지에서 검색 bar를 밑에 넣을 예정이라 이 테스트가 필요 없을 수 있다. 차후 구현 여부 결정
     @DisplayName("[view][GET] 게시글 검색 전용 페이지 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingArticleSearchView_thenReturnsArticleSearchView() throws Exception {
@@ -74,6 +95,7 @@ class ArticleControllerTest {
     }
 
     @Disabled("구현 중")
+    // ToDo: 검색 Service layer 완료되면 구현 필요.
     @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingArticleHashtagSearchView_thenReturnsArticleHashtagSearchView() throws Exception {
@@ -85,6 +107,35 @@ class ArticleControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(model().attributeExists("articles/search-hashtag"));;
         // 검색하면 목록 외에 게시글에 대한 데이터는 없어야 한다.
+    }
+
+    private ArticleWithCommentsDto createArticleWithCommentsDto() {
+        return ArticleWithCommentsDto.of(
+                1L,
+                createUserAccountDto(),
+                Set.of(),
+                "title",
+                "content",
+                "#java",
+                LocalDateTime.now(),
+                "uno",
+                LocalDateTime.now(),
+                "uno"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(1L,
+                "matrix",
+                "1234",
+                "matrixpower1004@mail.com",
+                "matrix",
+                "memo",
+                LocalDateTime.now(),
+                "matrix",
+                LocalDateTime.now(),
+                "matrix"
+        );
     }
 
 } // end of class

--- a/src/test/java/com/matrix/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/matrix/projectboard/service/ArticleServiceTest.java
@@ -169,10 +169,10 @@ class ArticleServiceTest {
 
     private UserAccount createUserAccount() {
         return UserAccount.of(
-                "uno",
-                "password",
-                "uno@email.com",
-                "Uno",
+                "matrix",
+                "1234",
+                "matrixpower1004@email.com",
+                "matrixpower",
                 null
         );
     }
@@ -197,23 +197,23 @@ class ArticleServiceTest {
                 content,
                 hashtag,
                 LocalDateTime.now(),
-                "Uno",
+                "matrix",
                 LocalDateTime.now(),
-                "Uno");
+                "matrix");
     }
 
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 1L,
-                "uno",
-                "password",
-                "uno@mail.com",
-                "Uno",
+                "matrix",
+                "1234",
+                "matrixpowerj1004@mail.com",
+                "matrixpower",
                 "This is memo",
                 LocalDateTime.now(),
-                "uno",
+                "matrix",
                 LocalDateTime.now(),
-                "uno"
+                "matrix"
         );
     }
 


### PR DESCRIPTION
- 게시판 기본 조회 화면을 위한 컨트롤러 구현
- View로 데이터 전달을 위한 ResponseDto 작성
- 게시판 페이지 기본 정렬 설정 : 1 페이지당 10개 게시글,  시간 내림차순
- 학습 내용 README 반영